### PR TITLE
feat: Spoonacular API基本設定とテスト機能を追加

### DIFF
--- a/src/app/Services/SpoonacularService.php
+++ b/src/app/Services/SpoonacularService.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+class SpoonacularService
+{
+    private $apiKey;
+    private $baseUrl = 'https://api.spoonacular.com/recipes';
+
+    public function __construct()
+    {
+        $this->apiKey = config('services.spoonacular.api_key');
+    }
+
+    /**
+     * API接続テスト用
+     */
+    public function testConnection()
+    {
+        try {
+            $response = Http::get($this->baseUrl . '/random', [
+                'apiKey' => $this->apiKey,
+                'number' => 1
+            ]);
+
+            return $response->successful();
+        } catch (\Exception $e) {
+            Log::error('API Connection Test Failed', ['message' => $e->getMessage()]);
+            return false;
+        }
+    }
+
+    public function getRandomRecipe($cuisine = null, $number = 1)
+    {
+        // 後で実装
+        return null;
+    }
+}

--- a/src/config/services.php
+++ b/src/config/services.php
@@ -35,4 +35,8 @@ return [
         ],
     ],
 
+    'spoonacular' => [
+    'api_key' => env('SPOONACULAR_API_KEY'),
+    ],
+
 ];

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -1,7 +1,16 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use App\Services\SpoonacularService;
 
 Route::get('/', function () {
     return view('welcome');
+});
+
+// API接続テスト用（後で削除）
+Route::get('/test-api', function (SpoonacularService $service) {
+    if ($service->testConnection()) {
+        return 'API接続成功！';
+    }
+    return 'API接続失敗...';
 });


### PR DESCRIPTION
- *SPOONACULAR_API_KEY*を取得して.envに記載
- APIサービスのクラスを作成
- APIテスト記述
- **% curl http://localhost:8080/test-api** で  **API接続成功!** 出力確認